### PR TITLE
Improve status dot alignment

### DIFF
--- a/github.css
+++ b/github.css
@@ -1,12 +1,12 @@
 a.cci{
-	margin-left: 0;
+	margin: -3px 8px 0 0;
 }
 	a.cci span.default-build-status{
 		display: inline-block;
 		border-radius: 50%;
 		background-color: #DEDEDE;
-		width: 11px;
-		height: 11px;
+		width: 12px;
+		height: 12px;
 		transition: background-color 2s;
 	}
 		a.cci span.default-build-status.passed{


### PR DESCRIPTION
The status dot was a little to low compared to the repo org name and
repo name. Also, for private repos, the status dot was right up against
the "private" label.

This PR fixes those issues.